### PR TITLE
Changes reason for anonymous cfps

### DIFF
--- a/_source/cfp/index.html
+++ b/_source/cfp/index.html
@@ -41,7 +41,7 @@ tagline: Because speaking at ArrrrCamp is arrrrsome!
     </p>
     <h2>The process</h2>
     <p>
-      The submissions we receive will be handled anonymously. That means that personal information is scrambled in the database until the selection process is over, at which point we will decode the personal information and get in touch. We hope this transparent approach will benefit the diversity of the conference, and that it will encourage underrepresented groups to submit proposals as well.
+      The submissions we receive will be handled anonymously. This allows us to judge proposals on their value for the conference and their content and exclude any biases we may have towards the author, subconscious or otherwise.
     </p>
     <p>
       Once again, we're a very welcoming bunch and would love to help out with any questions you may have.


### PR DESCRIPTION
I don't really believe anonymous proposals in and of themselves improve diversity, but I do think they might encourage people to submit when they know there won't be any bias towards people we know, or for example their gender.
